### PR TITLE
remove accentuated characters (lot of french words...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ https://www.apple.com/newsroom/2024/05/apple-news-plus-introduces-quartiles-a-ne
 
 The `words` used in Dockerfile is from Ubuntu's
 `apt install wamerican-large` american-english-large words-large
-removing 's and all caps acronyms
+removing 's and all caps acronyms and non ascii words
 ```
-grep -v "'" /usr/share/dict/american-english-large | grep -v -E "^[A-Z]+s?$" > words
+gnugrep -v -E -e "^[A-Z]+s?$" -e '[^a-zA-Z]' < /usr/share/dict/american-english-large > words
 ```

--- a/words
+++ b/words
@@ -1134,7 +1134,6 @@ Astrid
 AstroTurf
 Asturias
 Astyanax
-Asunción
 Asur
 Aswan
 Asyut
@@ -1146,7 +1145,6 @@ Atahualpa
 Atalanta
 Atari
 Atascadero
-Atatürk
 Atbara
 Atchafalaya
 Ate
@@ -1566,7 +1564,6 @@ Barth
 Barthes
 Bartholdi
 Bartholomew
-Bartók
 Bartlett
 Bartolommeo
 Barton
@@ -2111,7 +2108,6 @@ Boers
 Boethius
 Bogart
 Bogor
-Bogotá
 Bohemia
 Bohemian
 Bohemianism
@@ -2211,7 +2207,6 @@ Boston
 Bostonian
 Bostons
 Boswell
-Boötes
 Botha
 Bothnia
 Bothwell
@@ -2422,7 +2417,6 @@ Brittanies
 Brittany
 Britten
 Brittney
-Brünnhilde
 Brno
 Broad
 Broads
@@ -2632,7 +2626,6 @@ Bute
 Butler
 Butte
 Butterfingers
-Buñuel
 Buxtehude
 Byblos
 Bydgoszcz
@@ -3748,7 +3741,6 @@ Comus
 Con
 Conakry
 Conan
-Concepción
 Concetta
 Conchobar
 Concord
@@ -3914,7 +3906,6 @@ Cotswold
 Cotswolds
 Cottbus
 Cotton
-Couéism
 Coulomb
 Coulter
 Counselor
@@ -4193,7 +4184,6 @@ Damon
 Dampier
 Dan
 Dana
-Danaë
 Danaides
 Danang
 Danaus
@@ -4642,7 +4632,6 @@ Doolittle
 Doonesbury
 Doorn
 Doppler
-Doré
 Dora
 Dorado
 Dorcas
@@ -4715,7 +4704,6 @@ Drayton
 Dreibund
 Dreiser
 Drenthe
-Dürer
 Dresden
 Drew
 Dreyfus
@@ -4735,7 +4723,6 @@ Druze
 Dryad
 Dryden
 Dschubba
-Düsseldorf
 Du
 DuBois
 DuPont
@@ -4829,7 +4816,6 @@ Dutchwoman
 Duvalier
 Dvina
 Dvinsk
-Dvorák
 Dwaine
 Dwayne
 Dwight
@@ -5066,7 +5052,6 @@ Elwood
 Ely
 Elyot
 Elyria
-Elysée
 Elysian
 Elysium
 Elysiums
@@ -5277,7 +5262,6 @@ Estela
 Estella
 Estelle
 Ester
-Esterházy
 Estes
 Esth
 Esther
@@ -5419,7 +5403,6 @@ Ezechiel
 Ezek
 Ezekiel
 Ezra
-Fabergé
 Fabian
 Fabianism
 Fabianisms
@@ -5499,7 +5482,6 @@ Faulkner
 Faulknerian
 Fauntleroy
 Faunus
-Fauré
 Faust
 Faustian
 Faustino
@@ -5565,7 +5547,6 @@ Feuillant
 Feynman
 Fez
 Fezzan
-Führer
 Fianna
 Fiat
 Fiberglas
@@ -5897,7 +5878,6 @@ Furies
 Furman
 Furness
 Furnivall
-Furtwängler
 Fushih
 Fushun
 Futurism
@@ -6081,7 +6061,6 @@ Gaza
 Gaziantep
 Gd
 Gdansk
-Gödel
 Gdynia
 Ge
 GeV
@@ -6176,8 +6155,6 @@ Gethsemane
 Getty
 Gettysburg
 Geulincx
-Gewürztraminer
-Geëz
 Gezira
 Ghana
 Ghanaian
@@ -6524,7 +6501,6 @@ Griqua
 Gris
 Griselda
 Grisons
-Grünewald
 Grodno
 Groenendael
 Grolier
@@ -6546,8 +6522,6 @@ Grundyism
 Grundyisms
 Grus
 Gruyeres
-Gruyère
-Göteborg
 Guadalajara
 Guadalcanal
 Guadalquivir
@@ -6705,7 +6679,6 @@ Haley
 Halicarnassus
 Halifax
 Hall
-Hallé
 Hallel
 Hallels
 Halley
@@ -7223,7 +7196,6 @@ Hitlerism
 Hitlers
 Hittite
 Hittites
-Héloise
 Hmong
 Ho
 Hoad
@@ -7716,7 +7688,6 @@ Irishman
 Irishmen
 Irishwoman
 Irishwomen
-Iráklion
 Irkutsk
 Irma
 Iroquoian
@@ -8689,7 +8660,6 @@ Klemperer
 Klimt
 Kline
 Klingon
-Köln
 Klondike
 Klondikes
 Klopstock
@@ -9152,7 +9122,6 @@ Layla
 Layton
 Lazaro
 Lazarus
-Lübeck
 Ld
 Le
 Lea
@@ -9695,7 +9664,6 @@ Lully
 Lulu
 Luluabourg
 Luminal
-Lumière
 Lumumba
 Luna
 Lungki
@@ -9990,11 +9958,9 @@ Malinda
 Malines
 Malinowski
 Maliseet
-Mallarmé
 Mallomars
 Mallorca
 Mallory
-Malmö
 Malone
 Malory
 Malpighi
@@ -10072,7 +10038,6 @@ Mannerheim
 Mannheim
 Manning
 Manolete
-Manáos
 Mansfield
 Manson
 Manteca
@@ -10877,7 +10842,6 @@ Mlle
 Mme
 Mmes
 Mn
-Münchhausen
 Mnemosyne
 Mo
 Moab
@@ -11731,7 +11695,6 @@ Noxzema
 Noyce
 Noyes
 Np
-Nürnberg
 Nubia
 Nubian
 Nukualofa
@@ -12228,7 +12191,6 @@ Paralympic
 Paralympics
 Paramaribo
 Paramount
-Paraná
 Parashah
 Parcae
 Parcheesi
@@ -12750,13 +12712,11 @@ Podunk
 Poe
 Pogo
 Pohai
-Poincaré
 Poiret
 Poirot
 Poisson
 Poitier
 Poitiers
-Pokémon
 Pol
 Pola
 Polack
@@ -12955,7 +12915,6 @@ Proudhon
 Proust
 Proustian
 Prov
-Provençal
 Provencals
 Provence
 Proverbs
@@ -12965,7 +12924,6 @@ Provincetown
 Provo
 Prozac
 Prozacs
-Pôrto
 Prudence
 Prudential
 Pruitt
@@ -12984,7 +12942,6 @@ Pskov
 Psyche
 Pt
 Ptah
-Pétain
 Ptolemaeus
 Ptolemaic
 Ptolemaist
@@ -13094,7 +13051,6 @@ Quasimodo
 Quaternary
 Quathlamba
 Quayle
-Québecois
 Que
 Quebec
 Quebecer
@@ -13159,7 +13115,6 @@ Rae
 Raeburn
 Rafael
 Raffles
-Ragnarök
 Rainier
 Raj
 Rajab
@@ -13948,7 +13903,6 @@ Sandra
 Sandrocottus
 Sandwich
 Sandy
-Saône
 Sanford
 Sanforized
 Sang
@@ -14111,13 +14065,11 @@ Schloss
 Schmidt
 Schnabel
 Schnauzer
-Schönberg
 Schneider
 Schnitzler
 Schoenberg
 Schopenhauer
 Schopenhauerism
-Schrödinger
 Schrecklichkeit
 Schrieffer
 Schroeder
@@ -15174,7 +15126,6 @@ Sven
 Svengali
 Sverdlovsk
 Sverige
-Sèvres
 Sw
 Swabia
 Swabian
@@ -15353,7 +15304,6 @@ Tanisha
 Tanjore
 Tannenberg
 Tanner
-Tannhäuser
 Tanoan
 Tanta
 Tantalus
@@ -15621,7 +15571,6 @@ Thessalonian
 Thessalonians
 Thessalonica
 Thessalonike
-Thessaloníki
 Thessaly
 Thetis
 Thieu
@@ -16286,7 +16235,6 @@ Vallombrosa
 Valois
 Valona
 Valparaiso
-Valéry
 Valvoline
 Van
 Vance
@@ -16346,9 +16294,7 @@ Velcro
 Velcros
 Velez
 Velma
-Velásquez
 Velveeta
-Velázquez
 Ven
 Venetia
 Venetian
@@ -17276,7 +17222,6 @@ Zorro
 Zosma
 Zouave
 Zr
-Zürich
 Zsigmondy
 Zubenelgenubi
 Zubeneschamali
@@ -17350,7 +17295,6 @@ abattoir
 abattoirs
 abaxial
 abb
-abbé
 abba
 abbacies
 abbacy
@@ -17371,7 +17315,6 @@ abbreviation
 abbreviations
 abbreviator
 abbrevs
-abbés
 abcoulomb
 abcoulombs
 abdicate
@@ -18608,7 +18551,6 @@ adipocere
 adipose
 adiposities
 adiposity
-adiós
 adit
 adits
 adj
@@ -19779,8 +19721,6 @@ alcoholometer
 alcohols
 alcove
 alcoves
-alcázar
-alcázars
 aldehyde
 aldehydes
 alder
@@ -19995,7 +19935,6 @@ allay
 allayed
 allaying
 allays
-allée
 allegation
 allegations
 allege
@@ -21968,7 +21907,6 @@ anyways
 anywhere
 anywheres
 anywise
-aïoli
 aorist
 aoristic
 aorists
@@ -22014,8 +21952,6 @@ aperitifs
 apertural
 aperture
 apertures
-aperçu
-aperçus
 apery
 apes
 apetalous
@@ -22341,10 +22277,6 @@ applied
 applier
 appliers
 applies
-appliqué
-appliquéd
-appliquéing
-appliqués
 apply
 applying
 appoggiatura
@@ -23055,7 +22987,6 @@ arsonist
 arsonists
 arsphenamine
 art
-arête
 artefact
 artefacts
 artefactual
@@ -23078,7 +23009,6 @@ arteriovenous
 arteritis
 arteritises
 artery
-arêtes
 artesian
 artful
 artfully
@@ -23815,13 +23745,11 @@ atropine
 att
 attaboy
 attach
-attaché
 attachable
 attached
 attaching
 attachment
 attachments
-attachés
 attack
 attacked
 attacker
@@ -25927,7 +25855,6 @@ bawler
 bawling
 bawls
 bay
-bayadère
 bayard
 bayberries
 bayberry
@@ -26744,8 +26671,6 @@ berley
 berlin
 berlins
 berm
-Übermensch
-Übermenschen
 berms
 bermudas
 berretta
@@ -27859,7 +27784,6 @@ blarney
 blarneyed
 blarneying
 blarneys
-blasé
 blaspheme
 blasphemed
 blasphemer
@@ -29201,8 +29125,6 @@ boustrophedons
 bout
 boutique
 boutiques
-boutonnière
-boutonnières
 bouts
 bouzouki
 bouzoukis
@@ -31271,7 +31193,6 @@ caesarians
 caesura
 caesurae
 caesuras
-café
 cafard
 cafeteria
 cafeterias
@@ -31283,7 +31204,6 @@ caffeinated
 caffeine
 caffeins
 caffs
-cafés
 caftan
 caftans
 cage
@@ -31726,8 +31646,6 @@ canalized
 canalizes
 canalizing
 canals
-canapé
-canapés
 canard
 canards
 canaries
@@ -34073,13 +33991,11 @@ chasing
 chasm
 chasmic
 chasms
-chassé
 chassed
 chasseing
 chassepot
 chasseur
 chassis
-chassés
 chaste
 chastely
 chasten
@@ -35088,11 +35004,6 @@ chrysoprases
 chrysotile
 chrysotiles
 chs
-château
-châteaux
-châtelain
-châtelaine
-châtelaines
 chthonian
 chthonic
 chub
@@ -35205,7 +35116,6 @@ chutney
 chutneys
 chutzpa
 chutzpah
-chèvre
 chyack
 chyle
 chyles
@@ -35326,7 +35236,6 @@ ciphering
 ciphers
 cipolin
 cir
-ciré
 circa
 circadian
 circinate
@@ -35581,11 +35490,8 @@ claimer
 claimers
 claiming
 claims
-éclair
 clairaudience
 clairaudient
-éclaircissement
-éclairs
 clairvoyance
 clairvoyant
 clairvoyants
@@ -35753,7 +35659,6 @@ classrooms
 classwork
 classy
 clastic
-éclat
 clathrate
 clatter
 clattered
@@ -35918,9 +35823,6 @@ clew
 clewed
 clewing
 clews
-cliché
-clichéd
-clichés
 click
 clickable
 clickbait
@@ -35932,8 +35834,6 @@ clicks
 client
 clientage
 clientages
-clientèle
-clientèles
 clients
 clientship
 cliff
@@ -36086,7 +35986,6 @@ clogging
 cloggy
 clogs
 cloison
-cloisonné
 cloister
 cloistered
 cloistering
@@ -37782,8 +37681,6 @@ compounder
 compounding
 compounds
 comprador
-compère
-compèred
 comprehend
 comprehended
 comprehendible
@@ -37798,7 +37695,6 @@ comprehensive
 comprehensively
 comprehensiveness
 comprehensives
-compères
 compress
 compressed
 compresses
@@ -37812,7 +37708,6 @@ compressions
 compressive
 compressor
 compressors
-compèring
 comprise
 comprised
 comprises
@@ -38379,8 +38274,6 @@ confrontations
 confronted
 confronting
 confronts
-confrère
-confrères
 confusable
 confuse
 confused
@@ -38786,7 +38679,6 @@ consoling
 consolingly
 consols
 consolute
-consommé
 consonance
 consonances
 consonant
@@ -40062,8 +39954,6 @@ corsetry
 corsets
 cortex
 cortexes
-cortège
-cortèges
 cortical
 corticate
 cortices
@@ -40080,9 +39970,7 @@ coruscated
 coruscates
 coruscating
 coruscation
-corvée
 corves
-corvées
 corvette
 corvettes
 corvine
@@ -40288,8 +40176,6 @@ coughings
 coughs
 could
 couldst
-coulée
-coulées
 coulis
 coulisse
 coulisses
@@ -40996,10 +40882,6 @@ crazing
 crazy
 crazyweed
 crazyweeds
-crèche
-crèches
-córdoba
-córdobas
 creak
 creaked
 creakier
@@ -41518,9 +41400,7 @@ crotchetiness
 crotchets
 crotchety
 croton
-croûton
 crotons
-croûtons
 crouch
 crouched
 crouches
@@ -41595,7 +41475,6 @@ crudeness
 cruder
 crudest
 crudities
-crudités
 crudity
 cruel
 crueler
@@ -42050,7 +41929,6 @@ cupulate
 cupule
 cupules
 cur
-curaçao
 curability
 curable
 curacies
@@ -42376,8 +42254,6 @@ cyanotype
 cyathus
 cyberbullies
 cyberbully
-cybercafé
-cybercafés
 cybernaut
 cybernetic
 cybernetician
@@ -43007,16 +42883,7 @@ dazzling
 dazzlingly
 db
 dbl
-débridement
-débutant
-débutante
-débutantes
 dc
-déclassé
-déclassée
-décolleté
-décolletage
-décolletages
 dd
 dded
 dding
@@ -44985,8 +44852,6 @@ derrick
 derricks
 derringer
 derringers
-derrière
-derrières
 derris
 derrises
 derry
@@ -45606,7 +45471,6 @@ dextrously
 dextrousness
 dey
 dg
-dégagé
 dharana
 dharma
 dharna
@@ -45729,7 +45593,6 @@ diamagnetic
 diamagnetism
 diamagnetisms
 diamagnets
-diamanté
 diameter
 diameters
 diametral
@@ -47580,8 +47443,6 @@ distinctively
 distinctiveness
 distinctly
 distinctness
-distingué
-distinguée
 distinguish
 distinguishable
 distinguishably
@@ -47828,12 +47689,10 @@ divisiveness
 divisor
 divisors
 divorce
-divorcée
 divorced
 divorcement
 divorcements
 divorces
-divorcées
 divorcing
 divot
 divots
@@ -47882,9 +47741,6 @@ dkl
 dlr
 dlvy
 dm
-démarche
-démarches
-démodé
 do
 doable
 dob
@@ -48215,10 +48071,8 @@ donjon
 donjons
 donkey
 donkeys
-donné
 donna
 donnas
-donnée
 donned
 donning
 donnish
@@ -48310,8 +48164,6 @@ dopiest
 dopily
 dopiness
 doping
-doppelgänger
-doppelgängers
 dopy
 dor
 dora
@@ -48701,8 +48553,6 @@ dragrope
 drags
 dragster
 dragsters
-dérailleur
-dérailleurs
 drain
 drainage
 drainboard
@@ -49100,8 +48950,6 @@ drys
 drysalter
 drystone
 drywall
-déshabillé
-détente
 duad
 duads
 dual
@@ -51962,7 +51810,6 @@ entrapped
 entrapper
 entrapping
 entraps
-entrée
 entreat
 entreated
 entreaties
@@ -51988,7 +51835,6 @@ entrepreneurially
 entrepreneurism
 entrepreneurs
 entrepreneurship
-entrées
 entresol
 entries
 entropic
@@ -54593,7 +54439,6 @@ fads
 faecal
 faeces
 faena
-faïence
 faerie
 faeries
 faery
@@ -54622,7 +54467,6 @@ fails
 failure
 failures
 fain
-fainéant
 fainer
 fainest
 faint
@@ -55653,13 +55497,7 @@ fez
 fezes
 fezzes
 ff
-föhn
-föhns
 fiacre
-fiancé
-fiancée
-fiancées
-fiancés
 fiasco
 fiascoes
 fiascos
@@ -56431,11 +56269,9 @@ flaking
 flaky
 flam
 flamage
-flambé
 flambeau
 flambeaus
 flambeaux
-flambéed
 flambeing
 flambes
 flamboyance
@@ -58245,7 +58081,6 @@ frantic
 frantically
 franticly
 frap
-frappé
 frapped
 frappes
 frapping
@@ -58792,8 +58627,6 @@ fryer
 fryers
 frying
 ft
-fête
-fêtes
 fth
 ftp
 ftpers
@@ -59405,8 +59238,6 @@ galop
 galore
 galosh
 galoshes
-galère
-galères
 gals
 galumph
 galumphed
@@ -59654,8 +59485,6 @@ garnishing
 garnishment
 garnishments
 garniture
-garçon
-garçons
 garote
 garoted
 garotes
@@ -60014,7 +59843,6 @@ gemsbok
 gemsboks
 gemstone
 gemstones
-gemütlich
 gen
 genappe
 gendarme
@@ -60683,8 +60511,6 @@ glabella
 glabrate
 glabrescent
 glabrous
-glacé
-glacéed
 glacial
 glacialist
 glacially
@@ -60696,13 +60522,11 @@ glaciation
 glaciations
 glacier
 glaciers
-glacéing
 glaciological
 glaciologist
 glaciologists
 glaciology
 glacis
-glacés
 glad
 gladden
 gladdened
@@ -63097,7 +62921,6 @@ habitations
 habitats
 habited
 habits
-habitué
 habitual
 habitually
 habitualness
@@ -63108,7 +62931,6 @@ habituating
 habituation
 habitude
 habitudes
-habitués
 hacek
 haceks
 hachure
@@ -69839,8 +69661,6 @@ ingleside
 inglorious
 ingloriously
 ingloriousness
-ingénue
-ingénues
 ingoing
 ingot
 ingots
@@ -72178,8 +71998,6 @@ jails
 jakes
 jakeses
 jalap
-jalapeño
-jalapeños
 jalopies
 jalopy
 jalousie
@@ -72227,8 +72045,6 @@ japing
 japonica
 japonicas
 jar
-jardinière
-jardinières
 jarful
 jarfuls
 jargon
@@ -73528,8 +73344,6 @@ kindergarten
 kindergartener
 kindergarteners
 kindergartens
-kindergärtner
-kindergärtners
 kindest
 kindhearted
 kindheartedly
@@ -73718,8 +73532,6 @@ klutzy
 klystron
 klystrons
 km
-kümmel
-kümmels
 kn
 knack
 knacker
@@ -73960,8 +73772,6 @@ kriegspiel
 krill
 krimmer
 kris
-króna
-krónur
 krone
 kroner
 kronor
@@ -74378,7 +74188,6 @@ lampshade
 lampshades
 lampyrid
 lams
-élan
 lanai
 lanais
 lanate
@@ -76366,8 +76175,6 @@ littler
 littlest
 littoral
 littorals
-littérateur
-littérateurs
 liturgical
 liturgically
 liturgics
@@ -77533,7 +77340,6 @@ lytic
 lytta
 m
 ma
-mañana
 mac
 macabre
 macaco
@@ -77557,8 +77363,6 @@ macaroons
 macaw
 macaws
 maccaboy
-macédoine
-macédoines
 mace
 maced
 macerate
@@ -77609,7 +77413,6 @@ mackle
 mackles
 macks
 macle
-macramé
 macro
 macrobiotic
 macrobiotics
@@ -77697,11 +77500,7 @@ madrigalian
 madrigalist
 madrigalists
 madrigals
-madroña
-madroñas
 madrone
-madroño
-madroños
 mads
 maduro
 madwoman
@@ -77990,7 +77789,6 @@ maladroit
 maladroitly
 maladroitness
 malady
-malagueña
 malaise
 malamute
 malamutes
@@ -78266,7 +78064,6 @@ manganite
 manganites
 manganous
 mange
-manège
 manged
 manger
 mangers
@@ -78400,7 +78197,6 @@ manorial
 manorialism
 manors
 manpower
-manqué
 manrope
 mans
 mansard
@@ -79005,8 +78801,6 @@ mathematics
 matier
 matiest
 matin
-matinée
-matinées
 mating
 matings
 matins
@@ -79030,7 +78824,6 @@ matriculated
 matriculates
 matriculating
 matriculation
-matériel
 matrilateral
 matrilineage
 matrilineages
@@ -80600,7 +80393,6 @@ mighty
 mignon
 mignonette
 mignonettes
-émigré
 migraine
 migraines
 migrainous
@@ -80615,7 +80407,6 @@ migrational
 migrations
 migrator
 migratory
-émigrés
 mihrab
 mikado
 mikados
@@ -80757,7 +80548,6 @@ millihenry
 milliliter
 milliliters
 millime
-millième
 millimes
 millimeter
 millimeters
@@ -81646,8 +81436,6 @@ mkay
 mks
 mkt
 ml
-mêlée
-mêlées
 mm
 mneme
 mnemonic
@@ -82835,14 +82623,9 @@ mp
 mpg
 mph
 ms
-mésalliance
-mésalliances
 mt
 mtg
 mtge
-métier
-métiers
-métisses
 mu
 much
 muchness
@@ -83663,7 +83446,6 @@ naiveness
 naivenesses
 naiver
 naivest
-naiveté
 naivety
 naked
 nakedly
@@ -83975,7 +83757,6 @@ nays
 naysayer
 naysayers
 ne
-née
 neanderthal
 neanderthals
 neap
@@ -84157,7 +83938,6 @@ neglectfulness
 neglecting
 neglects
 neglig
-negligé
 negligee
 negligees
 negligence
@@ -84167,7 +83947,6 @@ negligibility
 negligible
 negligibly
 negligs
-negligés
 negotiability
 negotiable
 negotiant
@@ -84535,7 +84314,6 @@ next
 nextdoor
 nexus
 nexuses
-Ångström
 ngultrum
 ngultrums
 ngwee
@@ -86804,7 +86582,6 @@ okays
 oke
 okra
 okras
-olé
 old
 olde
 olden
@@ -88074,7 +87851,6 @@ output
 outputs
 outputted
 outputting
-outré
 outrace
 outraced
 outraces
@@ -90338,7 +90114,6 @@ pasquil
 pasquinade
 pasquinades
 pass
-passé
 passable
 passably
 passacaglia
@@ -90752,7 +90527,6 @@ pc
 pct
 pd
 pe
-épée
 pea
 peace
 peaceable
@@ -91216,7 +90990,6 @@ penologist
 penologists
 penology
 pens
-pensée
 pensile
 pension
 pensionable
@@ -91927,7 +91700,6 @@ perviousness
 perviousnesses
 pervs
 pes
-épées
 pesade
 peseta
 pesetas
@@ -92737,8 +92509,6 @@ pianos
 piassava
 piaster
 piasters
-piñata
-piñatas
 piazza
 piazzas
 piazze
@@ -92876,14 +92646,12 @@ piercings
 piers
 pies
 piet
-pietà
 pietism
 pietisms
 pietist
 pietistic
 pietistical
 pietistically
-pietàs
 piety
 piezochemistry
 piezoelectric
@@ -93210,13 +92978,11 @@ pinyin
 pinyon
 pinyons
 pion
-piñon
 pioneer
 pioneered
 pioneering
 pioneers
 pions
-piñons
 piosity
 pious
 piously
@@ -93270,8 +93036,6 @@ piques
 piquet
 piquets
 piquing
-piraña
-pirañas
 piracy
 piragua
 piranha
@@ -94188,7 +93952,6 @@ podcasts
 podded
 podding
 poddy
-podestà
 podgier
 podgiest
 podgy
@@ -94943,8 +94706,6 @@ portion
 portioned
 portioning
 portions
-portière
-portières
 portlier
 portliest
 portliness
@@ -95485,10 +95246,6 @@ prayerfully
 prayers
 praying
 prays
-précis
-précised
-précising
-père
 preach
 preached
 preacher
@@ -97520,10 +97277,6 @@ protesting
 protestor
 protestors
 protests
-protégé
-protégée
-protégées
-protégés
 prothalamion
 prothalamium
 prothallus
@@ -100562,7 +100315,6 @@ recheck
 rechecked
 rechecking
 rechecks
-recherché
 rechristen
 rechristened
 rechristening
@@ -102808,7 +102560,6 @@ repossesses
 repossessing
 repossession
 repossessions
-repoussé
 repp
 repps
 reprehend
@@ -103785,7 +103536,6 @@ retrospective
 retrospectively
 retrospectives
 retrospects
-retroussé
 retroversion
 retroversions
 retrovirus
@@ -104116,7 +103866,6 @@ rezone
 rezoned
 rezones
 rezoning
-régisseur
 rhabdomancy
 rhachis
 rhamnaceous
@@ -104574,7 +104323,6 @@ risks
 risky
 risotto
 risottos
-risqué
 rissole
 rissoles
 ristra
@@ -104649,8 +104397,6 @@ riyal
 riyals
 rm
 rms
-röntgen
-röntgens
 roach
 roached
 roaches
@@ -105083,7 +104829,6 @@ rotundity
 rotundly
 rotundness
 roturier
-roué
 rouge
 rouged
 rouges
@@ -105152,7 +104897,6 @@ roundups
 roundworm
 roundworms
 roup
-roués
 rouse
 roused
 rouser
@@ -105225,9 +104969,6 @@ rpm
 rps
 rpt
 rs
-réseau
-réseaus
-réseaux
 rt
 rte
 rub
@@ -106072,8 +105813,6 @@ sanatorium
 sanatoriums
 sanatory
 sanbenito
-séance
-séances
 sancta
 sanctification
 sanctified
@@ -106488,13 +106227,9 @@ sauropods
 saury
 sausage
 sausages
-sauté
 sauted
-sautéed
 sauterne
 sauternes
-sautéing
-sautés
 savable
 savage
 savaged
@@ -111630,8 +111365,6 @@ smoulder
 smouldered
 smouldering
 smoulders
-smörgåsbord
-smörgåsbords
 smriti
 smudge
 smudged
@@ -112205,8 +111938,6 @@ soggily
 sogginess
 soggy
 soh
-soigné
-soignée
 soil
 soilage
 soiled
@@ -112214,8 +111945,6 @@ soiling
 soils
 soilure
 soilures
-soirée
-soirées
 sojourn
 sojourned
 sojourner
@@ -112652,8 +112381,6 @@ soubrette
 soubrettes
 soubriquet
 soubriquets
-soufflé
-soufflés
 sough
 soughed
 soughing
@@ -112709,8 +112436,6 @@ souped
 soupier
 soupiest
 souping
-soupçon
-soupçons
 soups
 soupspoon
 soupspoons
@@ -118581,8 +118306,6 @@ taglines
 tagmeme
 tagmemic
 tagmemics
-étagère
-étagères
 tags
 tahini
 tahr
@@ -119732,7 +119455,6 @@ teniacide
 teniafuge
 tenias
 teniasis
-tenné
 tenner
 tenners
 tennis
@@ -121938,7 +121660,6 @@ totting
 toucan
 toucans
 touch
-touché
 touchable
 touchback
 touchbacks
@@ -123468,7 +123189,6 @@ trowing
 trows
 troy
 troys
-très
 truancy
 truant
 truanted
@@ -123679,8 +123399,6 @@ tuckers
 tucket
 tucking
 tucks
-étude
-études
 tufa
 tuff
 tuft
@@ -123702,8 +123420,6 @@ tugrik
 tugriks
 tugs
 tui
-étui
-étuis
 tuition
 tuitional
 tuitionary
@@ -123988,7 +123704,6 @@ tuxedo
 tuxedoes
 tuxedos
 tuxes
-tuyère
 twaddle
 twaddled
 twaddler
@@ -127872,7 +127587,6 @@ vaqueros
 var
 vara
 varas
-vargueño
 varia
 variability
 variable
@@ -128631,8 +128345,6 @@ victualing
 victualled
 victualling
 victuals
-vicuña
-vicuñas
 vide
 videlicet
 video
@@ -129163,7 +128875,6 @@ voided
 voider
 voiding
 voids
-voilà
 voile
 voiture
 vol


### PR DESCRIPTION
For some reason on Mac needs homebrew installed gnu grep otherwise `'[^a-zA-Z]'` doesn't somehow match `voilà` for instance